### PR TITLE
fix: typer.Exit must be raised to abort the program

### DIFF
--- a/src/ai4_metadata/utils.py
+++ b/src/ai4_metadata/utils.py
@@ -64,7 +64,9 @@ def _get_rich_console(stderr: bool = False) -> rich.console.Console:
     )
 
 
-def format_rich_error(error: exceptions.BaseExceptionError) -> None:
+def format_rich_error(
+    error: typing.Union[Exception, exceptions.BaseExceptionError]
+) -> None:
     """Format an error using rich."""
     console = _get_rich_console(stderr=True)
     console.print(


### PR DESCRIPTION
We were not raising typer.Exit() when there was an error, therefore the program exited with a status code of 0.

Fixes #27