### PR TITLE
feat: include initial mapping support for MLDCAT-AP

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ provide commands to validate and migrate the metadata files.
 
 ### Metadata validation
 
-The metadata utilities provide a command-line interface (CLI) tool
-`ai4-metadata-validate` that can be used to validate the metadata files. The
-CLI tool accepts the metadata files as input parameters.
+The metadata utilities provide a subcommand `ai4-metadata validate` that can be
+used to validate the metadata files. The CLI tool accepts the metadata files as
+input parameters.
 
     $ ai4-metadata validate instances/sample-v2.mods.json
     ╭─ Success ──────────────────────────────────────────────────────────────────╮
@@ -67,11 +67,33 @@ utilities will automatically detect the format.
     │ 'instances/sample-v2.mods.json' is valid for version 2.0.0                 │
     ╰────────────────────────────────────────────────────────────────────────────╯
 
+### Metadata mapping between different profiles and formats
+
+The metadata utilities provide a subcommand `ai4-metadata map` that can be used
+to map the `ai4` metadata into different metadata profiles and different output
+serialization formats. The supported profiles and formats are detailed below.
+
+#### MLDCAT-AP profile
+
+We support the [MLDCAT-AP](https://semiceu.github.io/MLDCAT-AP/) profile
+developed by the [SEMIC](https://interoperable-europe.ec.europa.eu/collection/semic-support-centre)
+support centre. The MLDCAT-AP profile is a metadata profile aimed to extend the
+use of [DCAT Aplication Profile](https://interoperable-europe.ec.europa.eu/collection/semic-support-centre/solution/dcat-application-profile-data-portals-europe)
+for data portals in Europe.
+
+In order to map the `ai4` metadata into the MLDCAT-AP profile you can use the
+`ai4-metadata map mldcat` subcommand. The input metadata file must be in the
+`ai4` metadata format (YAML or JSON). You can specify what format the metadata
+should be rendered into, either JSON-LD (`jsonld`) or RD Turtle (`ttl`).
+
+    $ ai4-metadata map mldcat instances/sample-v2.mods.json --output-format jsonld --output sample-v2.mldcat.jsonld
+    $ ai4-metadata map mldcat instances/sample-v2.mods.json --output-format ttl --output sample-v2.mldcat.ttl
+
 ### Metadata migration
 
-The metadata utilities provide a command-line interface (CLI) tool
-`ai4-metadata-migrate` that can be used to migrate the metadata files from V1
-to latest V2. To save the output, use the `--output` option.
+The metadata utilities provide a subcommand `ai4-metadata migrate` that can be
+used to migrate the metadata files from V1 to latest V2. To save the output,
+use the `--output` option.
 
     $ ai4-metadata migrate --output sample-v2.mods.json instances/sample-v1.mods.json
     ╭─ Success ──────────────────────────────────────────────────────────────────╮

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ jsonschema = "^4.23.0"
 rfc3987 = "^1.3.8"
 typer = "^0.12.4"
 pyyaml = "^6.0.2"
+rdflib = "^7.1.3"
 
 [tool.poetry.group.dev.dependencies]
 tox = "^4.17.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 "Bug Tracker" = "https://github.com/ai4os/ai4-metadata/issues"
 
 [tool.poetry.scripts]
-ai4-metadata-validator = "ai4_metadata.validate:validate_main"
-ai4-metadata-migrate = "ai4_metadata.migrate:migrate_main"
+ai4-metadata-validator = "ai4_metadata.validate:_validate_main"
+ai4-metadata-migrate = "ai4_metadata.migrate:_migrate_main"
 ai4-metadata = "ai4_metadata.cli:app"
 
 [tool.poetry.dependencies]

--- a/src/ai4_metadata/__init__.py
+++ b/src/ai4_metadata/__init__.py
@@ -4,7 +4,11 @@ from contextlib import suppress
 import importlib.metadata
 import pathlib
 
-import enum
+from . import metadata
+from . import generate
+from . import migrate
+from . import mapping
+from . import validate
 
 __version__ = "2.3.1"
 
@@ -23,36 +27,25 @@ def extract_version() -> str:
     return importlib.metadata.version(__package__ or __name__.split(".", maxsplit=1)[0])
 
 
-class MetadataVersions(str, enum.Enum):
-    """Available versions of the AI4 metadata schema."""
-
-    V2 = "2.2.0"
-    V2_2_0 = "2.2.0"
-    V2_1_0 = "2.1.0"
-    V2_0_0 = "2.0.0"
-
-    V1 = "1.0.0"
+MetadataVersions = metadata.MetadataVersions
+get_latest_version = metadata.get_latest_version
+get_schema = metadata.get_schema
 
 
-_metadata_version_files = {
-    MetadataVersions.V1: pathlib.Path(
-        pathlib.Path(__file__).parent
-        / f"schemata/ai4-apps-v{MetadataVersions.V1._value_}.json"  # noqa(W503)
-    ),
-    MetadataVersions.V2: pathlib.Path(
-        pathlib.Path(__file__).parent
-        / f"schemata/ai4-apps-v{MetadataVersions.V2._value_}.json"  # noqa(W503)
-    ),
-}
-
-LATEST_METADATA_VERSION = MetadataVersions.V2
-
-
-def get_latest_version() -> MetadataVersions:
-    """Get the latest version of the AI4 metadata schema."""
-    return LATEST_METADATA_VERSION
-
-
-def get_schema(version: MetadataVersions) -> pathlib.Path:
-    """Get the schema file path for a given version."""
-    return _metadata_version_files[version]
+__all__ = [
+    # From medatada.py
+    "MetadataVersions",
+    "get_latest_version",
+    "get_schema",
+    # From generate.py
+    "generate",
+    # From migrate.py
+    "migrate",
+    # From mapping
+    "mapping",
+    # From validate.py
+    "validate",
+    # From __init__.py
+    "extract_version",
+    "__version__",
+]

--- a/src/ai4_metadata/cli.py
+++ b/src/ai4_metadata/cli.py
@@ -5,6 +5,7 @@ import typer
 import ai4_metadata
 from ai4_metadata import generate
 from ai4_metadata import migrate
+from ai4_metadata import mapping
 from ai4_metadata import validate
 
 app = typer.Typer(help="AI4 Metadata tools and utils.")
@@ -14,6 +15,7 @@ app = typer.Typer(help="AI4 Metadata tools and utils.")
 app.registered_commands += generate.app.registered_commands
 app.registered_commands += migrate.app.registered_commands
 app.registered_commands += validate.app.registered_commands
+app.registered_commands += mapping.app.registered_commands
 
 
 def version_callback(value: bool):

--- a/src/ai4_metadata/cli.py
+++ b/src/ai4_metadata/cli.py
@@ -15,7 +15,12 @@ app = typer.Typer(help="AI4 Metadata tools and utils.")
 app.registered_commands += generate.app.registered_commands
 app.registered_commands += migrate.app.registered_commands
 app.registered_commands += validate.app.registered_commands
-app.registered_commands += mapping.app.registered_commands
+
+# NOTE(aloga): Instead, here we want to use add_typer to add the mapping commands as
+# subcommands of the main app. Then, inside the mapping module, we will use app =
+# typer.Typer() to create a new command group, and use registered_commands to add the
+# commands to the new group.
+app.add_typer(mapping.app, name="map")
 
 
 def version_callback(value: bool):

--- a/src/ai4_metadata/exceptions.py
+++ b/src/ai4_metadata/exceptions.py
@@ -87,3 +87,14 @@ class MetadataValidationError(BaseExceptionError):
             path = os.path.join(*[str(i) for i in e.absolute_path])
             message += f"\nParameter: [bold yellow]{path}[/bold yellow]"
         super().__init__(self.message.format(instance_file=instance_file, e=message))
+
+
+class InvalidMappingError(BaseExceptionError):
+    """Exception raised when a mapping is invalid."""
+
+    message = "Error generating mapping: {msg}"
+
+    def __init__(self, msg: str):
+        """Initialize the exception."""
+        self.msg = msg
+        super().__init__(self.message.format(msg=msg))

--- a/src/ai4_metadata/generate.py
+++ b/src/ai4_metadata/generate.py
@@ -8,7 +8,7 @@ from typing import Union, Any
 
 import typer
 
-import ai4_metadata
+from ai4_metadata import metadata
 from ai4_metadata import exceptions
 from ai4_metadata import utils
 from ai4_metadata import validate
@@ -72,11 +72,11 @@ def _get_field_value(value: dict, sample_values: bool = False) -> Any:
 
 
 @app.command(name="generate")
-def main(
+def _main(
     metadata_version: Annotated[
-        ai4_metadata.MetadataVersions,
+        metadata.MetadataVersions,
         typer.Option(help="AI4 application metadata version."),
-    ] = ai4_metadata.get_latest_version(),
+    ] = metadata.get_latest_version(),
     sample_values: Annotated[
         bool, typer.Option("--sample-values", help="Generate sample values.")
     ] = False,
@@ -89,7 +89,7 @@ def main(
     ] = None,
 ):
     """Generate an AI4 metadata schema."""
-    schema = ai4_metadata.get_schema(metadata_version)
+    schema = metadata.get_schema(metadata_version)
 
     try:
         generated_json = generate(schema, sample_values, required)

--- a/src/ai4_metadata/mapping/__init__.py
+++ b/src/ai4_metadata/mapping/__init__.py
@@ -1,0 +1,83 @@
+"""Module for mapping metadata between different formats."""
+
+import pathlib
+from typing_extensions import Annotated
+from typing import Optional
+
+import ai4_metadata
+from ai4_metadata import exceptions
+from ai4_metadata.mapping.profiles import mldcat
+from ai4_metadata import utils
+from ai4_metadata import validate
+
+import typer
+
+app = typer.Typer(help="Crosswalk metadata between different formats.")
+
+
+# We only support one profile so far
+SupportedInputProfiles = mldcat.SupportedInputProfiles
+
+
+@app.command(name="map")
+def _map(
+    from_file: Annotated[
+        pathlib.Path,
+        typer.Argument(help="File to map from."),
+    ],
+    to_format: Annotated[
+        mldcat.SupportedOutputFormats,
+        typer.Option(
+            "--output-format",
+            help="Format to map to. Note that this depends on the input format.",
+        ),
+    ],
+    to_profile: Annotated[
+        mldcat.SupportedOutputProfiles,
+        typer.Option("--output-profile", help="Profile to map to."),
+    ],
+    from_profile: Annotated[
+        SupportedInputProfiles,
+        typer.Option("--input-profile", help="Profile to map from."),
+    ] = SupportedInputProfiles.ai4os,
+    output: Annotated[
+        Optional[pathlib.Path],
+        typer.Option("--output", "-o", help="Output file for generated mapping."),
+    ] = None,
+    metadata_version: Annotated[
+        ai4_metadata.MetadataVersions,
+        typer.Option(help="AI4 application metadata version."),
+    ] = ai4_metadata.get_latest_version(),
+) -> None:
+    """Generate a mapping file between two formats."""
+    schema = ai4_metadata.get_schema(metadata_version)
+    try:
+        validate.validate(from_file, schema)
+    except exceptions.MetadataValidationError as e:
+        utils.format_rich_error(e)
+        raise typer.Exit(1)
+    except Exception as e:
+        utils.format_rich_error(e)
+        raise typer.Exit(4)
+
+    try:
+        metadata = utils.load_json(from_file)
+    except exceptions.InvalidJSONError:
+        metadata = utils.load_yaml(from_file)
+
+    if to_profile == mldcat.SupportedOutputProfiles.mldcat:
+        try:
+            mapping = mldcat.generate_mapping(
+                from_profile=from_profile,
+                from_metadata=metadata,
+                to_format=to_format,
+            )
+        except exceptions.InvalidMappingError as e:
+            utils.format_rich_error(e)
+            raise typer.Exit(1)
+
+    if output:
+        with open(output, "wb") as f:
+            f.write(mapping.encode("utf-8"))
+    else:
+        typer.echo(mapping)

--- a/src/ai4_metadata/mapping/__init__.py
+++ b/src/ai4_metadata/mapping/__init__.py
@@ -1,10 +1,11 @@
 """Module for mapping metadata between different formats."""
 
+import enum
 import pathlib
 from typing_extensions import Annotated
 from typing import Optional
 
-import ai4_metadata
+from ai4_metadata import metadata
 from ai4_metadata import exceptions
 from ai4_metadata.mapping.profiles import mldcat
 from ai4_metadata import utils
@@ -15,25 +16,113 @@ import typer
 app = typer.Typer(help="Crosswalk metadata between different formats.")
 
 
-# We only support one profile so far
-SupportedInputProfiles = mldcat.SupportedInputProfiles
+class SupportedInputProfiles(str, enum.Enum):
+    """Supported input profiles for crosswalks."""
+
+    ai4os = "ai4os"
 
 
-@app.command(name="map")
+class SupportedOutputProfiles(str, enum.Enum):
+    """Supported output profiles for crosswalks."""
+
+    mldcat = mldcat.SupportedOutputProfiles.mldcat.value
+
+
+class OutputFormatMapping(enum.Enum):
+    """Supported output formats for crosswalks."""
+
+    mldcat = list(mldcat.SupportedOutputFormats.__members__.values())
+
+
+def generate_output_formats() -> enum.Enum:
+    """Generate the output formats for the command."""
+    output_formats = {}
+
+    for _, allowed_formats in OutputFormatMapping.__members__.items():
+        for format_ in allowed_formats.value:
+            output_formats[format_.name] = format_.value
+
+    return enum.Enum("OutputFormatMapping", output_formats)
+
+
+SupportedOutputFormats = generate_output_formats()
+
+
+def mapping(
+    from_metadata: dict,
+    from_profile: SupportedInputProfiles,
+    to_format: mldcat.SupportedOutputFormats,
+    to_profile: SupportedOutputProfiles,
+    metadata_version: metadata.MetadataVersions,
+) -> str:
+    """Generate a mapping file for a given input and output format.
+
+    This command does not validate the input metadata, so it is assumed to be
+    correct. If the input metadata is not correct, the command will fail with
+    an exception.
+    """
+    if from_profile not in SupportedInputProfiles.__members__:
+        raise exceptions.InvalidMappingError(
+            msg=f"input format `{from_profile}` not supported."
+        )
+    if to_profile not in mldcat.SupportedOutputProfiles.__members__:
+        raise exceptions.InvalidMappingError(
+            msg=f"output format `{to_profile}` not supported."
+        )
+
+    if to_profile == mldcat.SupportedOutputProfiles.mldcat:
+        try:
+            mapping = mldcat.generate_mapping(
+                from_profile=from_profile,
+                from_metadata=from_metadata,
+                to_format=to_format,
+                metadata_version=metadata_version,
+            )
+        except exceptions.InvalidMappingError as e:
+            utils.format_rich_error(e)
+            raise typer.Exit(1)
+    else:
+        raise NotImplementedError(
+            f"output profile `{to_profile}` not supported for MLDCAT-API profile."
+        )
+
+    return mapping
+
+
+help_aux_str = ""
+
+for profile, allowed_formats in OutputFormatMapping.__members__.items():
+    for value in allowed_formats.value:
+        help_aux_str += f"\t\t- {profile}: {value.value}\n\n"
+
+
+@app.command(
+    name="map",
+    help=f"""
+    Generate a mapping file between two formats.
+
+    Supported output formats are dependant on the output profile. The following
+    profiles and formats are supported.
+
+    {help_aux_str}
+    """,
+)
 def _map(
     from_file: Annotated[
         pathlib.Path,
         typer.Argument(help="File to map from."),
     ],
-    to_format: Annotated[
-        mldcat.SupportedOutputFormats,
+    # Ignore type because mypy cannot infer the type of the enum type that
+    # we dynamically define above
+    to_format: Annotated[  # type: ignore
+        SupportedOutputFormats,
         typer.Option(
             "--output-format",
             help="Format to map to. Note that this depends on the input format.",
         ),
     ],
     to_profile: Annotated[
-        mldcat.SupportedOutputProfiles,
+        SupportedOutputProfiles,
         typer.Option("--output-profile", help="Profile to map to."),
     ],
     from_profile: Annotated[
@@ -45,12 +134,12 @@ def _map(
         typer.Option("--output", "-o", help="Output file for generated mapping."),
     ] = None,
     metadata_version: Annotated[
-        ai4_metadata.MetadataVersions,
+        metadata.MetadataVersions,
         typer.Option(help="AI4 application metadata version."),
-    ] = ai4_metadata.get_latest_version(),
+    ] = metadata.get_latest_version(),
 ) -> None:
     """Generate a mapping file between two formats."""
-    schema = ai4_metadata.get_schema(metadata_version)
+    schema = metadata.get_schema(metadata_version)
     try:
         validate.validate(from_file, schema)
     except exceptions.MetadataValidationError as e:
@@ -61,24 +150,14 @@ def _map(
         raise typer.Exit(4)
 
     try:
-        metadata = utils.load_json(from_file)
+        meta = utils.load_json(from_file)
     except exceptions.InvalidJSONError:
-        metadata = utils.load_yaml(from_file)
+        meta = utils.load_yaml(from_file)
 
-    if to_profile == mldcat.SupportedOutputProfiles.mldcat:
-        try:
-            mapping = mldcat.generate_mapping(
-                from_profile=from_profile,
-                from_metadata=metadata,
-                to_format=to_format,
-                metadata_version=metadata_version,
-            )
-        except exceptions.InvalidMappingError as e:
-            utils.format_rich_error(e)
-            raise typer.Exit(1)
+    aux = mapping(meta, from_profile, to_format, to_profile, metadata_version)
 
     if output:
         with open(output, "wb") as f:
-            f.write(mapping.encode("utf-8"))
+            f.write(aux.encode("utf-8"))
     else:
-        typer.echo(mapping)
+        typer.echo(aux)

--- a/src/ai4_metadata/mapping/__init__.py
+++ b/src/ai4_metadata/mapping/__init__.py
@@ -1,163 +1,22 @@
 """Module for mapping metadata between different formats."""
 
 import enum
-import pathlib
-from typing_extensions import Annotated
-from typing import Optional
 
-from ai4_metadata import metadata
-from ai4_metadata import exceptions
 from ai4_metadata.mapping.profiles import mldcat
-from ai4_metadata import utils
-from ai4_metadata import validate
 
 import typer
 
-app = typer.Typer(help="Crosswalk metadata between different formats.")
-
-
-class SupportedInputProfiles(str, enum.Enum):
-    """Supported input profiles for crosswalks."""
-
-    ai4os = "ai4os"
+app = typer.Typer(help="Crosswalk between different metadata profiles and formats.")
+# NOTE(aloga): do not use app.add_typer(<module>.app) as it will create a command group
+# and add all commands as subcommands of that group.
+# Check https://github.com/fastapi/typer/issues/187 for more details
+app.registered_commands += mldcat.app.registered_commands
 
 
 class SupportedOutputProfiles(str, enum.Enum):
     """Supported output profiles for crosswalks."""
 
-    mldcat = mldcat.SupportedOutputProfiles.mldcat.value
+    mldcat = mldcat
 
 
-class OutputFormatMapping(enum.Enum):
-    """Supported output formats for crosswalks."""
-
-    mldcat = list(mldcat.SupportedOutputFormats.__members__.values())
-
-
-def generate_output_formats() -> enum.Enum:
-    """Generate the output formats for the command."""
-    output_formats = {}
-
-    for _, allowed_formats in OutputFormatMapping.__members__.items():
-        for format_ in allowed_formats.value:
-            output_formats[format_.name] = format_.value
-
-    return enum.Enum("OutputFormatMapping", output_formats)
-
-
-SupportedOutputFormats = generate_output_formats()
-
-
-def mapping(
-    from_metadata: dict,
-    from_profile: SupportedInputProfiles,
-    to_format: mldcat.SupportedOutputFormats,
-    to_profile: SupportedOutputProfiles,
-    metadata_version: metadata.MetadataVersions,
-) -> str:
-    """Generate a mapping file for a given input and output format.
-
-    This command does not validate the input metadata, so it is assumed to be
-    correct. If the input metadata is not correct, the command will fail with
-    an exception.
-    """
-    if from_profile not in SupportedInputProfiles.__members__:
-        raise exceptions.InvalidMappingError(
-            msg=f"input format `{from_profile}` not supported."
-        )
-    if to_profile not in mldcat.SupportedOutputProfiles.__members__:
-        raise exceptions.InvalidMappingError(
-            msg=f"output format `{to_profile}` not supported."
-        )
-
-    if to_profile == mldcat.SupportedOutputProfiles.mldcat:
-        try:
-            mapping = mldcat.generate_mapping(
-                from_profile=from_profile,
-                from_metadata=from_metadata,
-                to_format=to_format,
-                metadata_version=metadata_version,
-            )
-        except exceptions.InvalidMappingError as e:
-            utils.format_rich_error(e)
-            raise typer.Exit(1)
-    else:
-        raise NotImplementedError(
-            f"output profile `{to_profile}` not supported for MLDCAT-API profile."
-        )
-
-    return mapping
-
-
-help_aux_str = ""
-
-for profile, allowed_formats in OutputFormatMapping.__members__.items():
-    for value in allowed_formats.value:
-        help_aux_str += f"\t\t- {profile}: {value.value}\n\n"
-
-
-@app.command(
-    name="map",
-    help=f"""
-    Generate a mapping file between two formats.
-
-    Supported output formats are dependant on the output profile. The following
-    profiles and formats are supported.
-
-    {help_aux_str}
-    """,
-)
-def _map(
-    from_file: Annotated[
-        pathlib.Path,
-        typer.Argument(help="File to map from."),
-    ],
-    # Ignore type because mypy cannot infer the type of the enum type that
-    # we dynamically define above
-    to_format: Annotated[  # type: ignore
-        SupportedOutputFormats,
-        typer.Option(
-            "--output-format",
-            help="Format to map to. Note that this depends on the input format.",
-        ),
-    ],
-    to_profile: Annotated[
-        SupportedOutputProfiles,
-        typer.Option("--output-profile", help="Profile to map to."),
-    ],
-    from_profile: Annotated[
-        SupportedInputProfiles,
-        typer.Option("--input-profile", help="Profile to map from."),
-    ] = SupportedInputProfiles.ai4os,
-    output: Annotated[
-        Optional[pathlib.Path],
-        typer.Option("--output", "-o", help="Output file for generated mapping."),
-    ] = None,
-    metadata_version: Annotated[
-        metadata.MetadataVersions,
-        typer.Option(help="AI4 application metadata version."),
-    ] = metadata.get_latest_version(),
-) -> None:
-    """Generate a mapping file between two formats."""
-    schema = metadata.get_schema(metadata_version)
-    try:
-        validate.validate(from_file, schema)
-    except exceptions.MetadataValidationError as e:
-        utils.format_rich_error(e)
-        raise typer.Exit(1)
-    except Exception as e:
-        utils.format_rich_error(e)
-        raise typer.Exit(4)
-
-    try:
-        meta = utils.load_json(from_file)
-    except exceptions.InvalidJSONError:
-        meta = utils.load_yaml(from_file)
-
-    aux = mapping(meta, from_profile, to_format, to_profile, metadata_version)
-
-    if output:
-        with open(output, "wb") as f:
-            f.write(aux.encode("utf-8"))
-    else:
-        typer.echo(aux)
+__all__ = ["app", "mldcat", "SupportedOutputProfiles"]

--- a/src/ai4_metadata/mapping/__init__.py
+++ b/src/ai4_metadata/mapping/__init__.py
@@ -71,6 +71,7 @@ def _map(
                 from_profile=from_profile,
                 from_metadata=metadata,
                 to_format=to_format,
+                metadata_version=metadata_version,
             )
         except exceptions.InvalidMappingError as e:
             utils.format_rich_error(e)

--- a/src/ai4_metadata/mapping/json-ld/mldcat-ap-context-2.0.0.jsonld
+++ b/src/ai4_metadata/mapping/json-ld/mldcat-ap-context-2.0.0.jsonld
@@ -1,0 +1,90 @@
+{
+	"@context": {
+		"@version" : 1.1,
+		"@import" : "https://semiceu.github.io/uri.semic.eu-generated/MLDCAT-AP/releases/2.1.0/context/mldcat-ap.jsonld",
+		"dcat" : "http://www.w3.org/ns/dcat#",
+		"dct" : "http://purl.org/dc/terms/",
+		"it6" : "http://data.europa.eu/it6/",
+		"xsd" : "http://www.w3.org/2001/XMLSchema#",
+		"title" : {
+			"@id" : "dct:title",
+			"@language" : "en"
+		},
+		"summary" : {
+			"@id" : "it6:shortDescription",
+			"@language" : "en"
+		},
+		"description" : {
+			"@id" : "dct:description",
+			"@language" : "en"
+		},
+		"dates" : "@nest",
+		"created" : {
+			"@id" : "dct:created",
+			"@type" : "xsd:date"
+		},
+		"updated" : {
+			"@id" : "dct:modified",
+			"@type" : "xsd:date"
+		},
+		"links" : "@nest",
+		"source_code" : {
+			"@id" : "it6:hasRepository",
+			"@type" : "@id"
+		},
+		"docker_image" : {
+			"@id" : "it6:hasRepository",
+			"@type" : "@id",
+			"@context" : {
+				"@base" : "https://hub.docker.com/r/"
+			}
+		},
+		"dataset" : {
+			"@id" : "it6:trainedOn",
+			"@type" : "@id"
+		},
+		"citation" : {
+			"@id" : "it6:hasBibliographicReference",
+			"@type" : "@id"
+		},
+		"base_model" : {
+			"@id" : "it6:fineTunedFrom",
+			"@type" : "@id"
+		},
+		"tags" : {
+			"@id" : "dcat:keyword",
+			"@language" : "en"
+		},
+		"tasks" : {
+			"@id" : "it6:hasTaskType",
+			"@type" : "@id",
+			"@context" : {
+				"@base" : "https://api.cloud.ai4eosc.eu/v1/catalog/tasktype/"
+			}
+		},
+		"categories" : {
+			"@id" : "dct:type",
+			"@type" : "@id",
+			"@context" : {
+				"@base" : "https://api.cloud.ai4eosc.eu/v1/catalog/category/"
+			}
+		},
+		"libraries" : {
+			"@id" : "it6:hasMachineLearningLibrary",
+			"@type" : "@id",
+			"@context" : {
+				"@base" : "https://api.cloud.ai4eosc.eu/v1/catalog/library/"
+		   }
+		},
+		"license" : {
+			"@id" : "dct:license",
+			"@type" : "@id",
+			"@context" : {
+				"@base" : "http://publications.europa.eu/resource/authority/licence/"
+			}
+		},
+		"type" : "@type",
+		"id" : "dct:identifier",
+		"uri" : "@id"
+	}
+}

--- a/src/ai4_metadata/mapping/profiles/__init__.py
+++ b/src/ai4_metadata/mapping/profiles/__init__.py
@@ -1,0 +1,1 @@
+"""Profiles to map from and to."""

--- a/src/ai4_metadata/mapping/profiles/__init__.py
+++ b/src/ai4_metadata/mapping/profiles/__init__.py
@@ -1,1 +1,5 @@
 """Profiles to map from and to."""
+
+from . import mldcat
+
+__all__ = ["mldcat"]

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -6,15 +6,24 @@ import json
 
 import rdflib
 
+import ai4_metadata
 from ai4_metadata import exceptions
 
 
 # FIXME(aloga): this is a placeholder for now, change to final value when we merge
 # the code in the main branch
-MLDCAT_JSON_LD_FILE = (
-    "https://semiceu.github.io/EOSC-MLDCAT-AP-Pilot/example/"
-    "eosc2.0.0-mldcat-ap-context.jsonld"
+_url_prefix = (
+    "https://github.com/ai4os/ai4-metadata/raw/refs/heads/mldcat-ap/src/"
+    "ai4_metadata/mapping/json-ld/"
 )
+MetadataVersions = ai4_metadata.MetadataVersions
+
+_JSON_LD_CONTEXT = {
+    MetadataVersions.V2: f"{_url_prefix}/mldcat-ap-context-2.0.0.jsonld",
+    MetadataVersions.V2_2_0: f"{_url_prefix}/mldcat-ap-context-2.0.0.jsonld",
+    MetadataVersions.V2_1_0: f"{_url_prefix}/mldcat-ap-context-2.0.0.jsonld",
+    MetadataVersions.V2_0_0: f"{_url_prefix}/mldcat-ap-context-2.0.0.jsonld",
+}
 
 
 class SupportedInputProfiles(str, enum.Enum):
@@ -40,6 +49,7 @@ def generate_mapping(
     from_profile: SupportedInputProfiles,
     from_metadata: dict,
     to_format: SupportedOutputFormats,
+    metadata_version: MetadataVersions = MetadataVersions.V2,
 ) -> str:
     """Generate a mapping file for a given input and output format."""
     if from_profile not in SupportedInputProfiles.__members__:
@@ -57,7 +67,7 @@ def generate_mapping(
         uri = from_metadata.get("links", {}).get("source_code", "")
 
     new_meta = copy.deepcopy(from_metadata)
-    new_meta["@context"] = MLDCAT_JSON_LD_FILE
+    new_meta["@context"] = _JSON_LD_CONTEXT[metadata_version]
     new_meta["uri"] = uri
     new_meta["type"] = "MachineLearningModel"
 

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -71,6 +71,18 @@ def generate_mapping(
     new_meta["uri"] = uri
     new_meta["type"] = "MachineLearningModel"
 
+    # FIXME(aloga): we replace this here, manually, but ai4os metadata should be
+    # fixed to use the correct format, and not use strings but objects.
+    new_meta["categories"] = [
+        cat.replace(" ", "_") for cat in new_meta.get("categories", [])
+    ]
+    new_meta["tasks"] = [
+        task.replace(" ", "_") for task in new_meta.get("tasks", [])
+    ]
+    new_meta["libraries"] = [
+        lib.replace(" ", "_") for lib in new_meta.get("libraries", [])
+    ]
+
     if to_format == SupportedOutputFormats.ttl:
         graph = rdflib.Graph()
         graph.parse(data=json.dumps(new_meta), format="json-ld")

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -1,0 +1,70 @@
+"""Module to generate mappings from AI4OS metadata to MLDCAT-API."""
+
+import copy
+import enum
+import json
+
+import rdflib
+
+from ai4_metadata import exceptions
+
+
+# FIXME(aloga): this is a placeholder for now, change to final value when we merge
+# the code in the main branch
+MLDCAT_JSON_LD_FILE = (
+    "https://semiceu.github.io/EOSC-MLDCAT-AP-Pilot/example/"
+    "eosc2.0.0-mldcat-ap-context.jsonld"
+)
+
+
+class SupportedInputProfiles(str, enum.Enum):
+    """Supported input profiles for crosswalks."""
+
+    ai4os = "ai4os"
+
+
+class SupportedOutputFormats(str, enum.Enum):
+    """Supported input formats for crosswalks."""
+
+    jsonld = "jsonld"
+    ttl = "ttl"
+
+
+class SupportedOutputProfiles(str, enum.Enum):
+    """Supported output profiles for crosswalks."""
+
+    mldcat = "mldcat"
+
+
+def generate_mapping(
+    from_profile: SupportedInputProfiles,
+    from_metadata: dict,
+    to_format: SupportedOutputFormats,
+) -> str:
+    """Generate a mapping file for a given input and output format."""
+    if from_profile not in SupportedInputProfiles.__members__:
+        raise exceptions.InvalidMappingError(
+            msg=f"input format `{from_profile}` not supported for MLDCAT-API profile."
+        )
+
+    if to_format not in SupportedOutputFormats.__members__:
+        raise exceptions.InvalidMappingError(
+            msg=f"output format `{to_format}` not supported for MLDCAT-API profile."
+        )
+
+    uri = from_metadata.get("links", {}).get("self", "")
+    if not uri:
+        uri = from_metadata.get("links", {}).get("source_code", "")
+
+    new_meta = copy.deepcopy(from_metadata)
+    new_meta["@context"] = MLDCAT_JSON_LD_FILE
+    new_meta["uri"] = uri
+    new_meta["type"] = "MachineLearningModel"
+
+    if to_format == SupportedOutputFormats.ttl:
+        graph = rdflib.Graph()
+        graph.parse(data=json.dumps(new_meta), format="json-ld")
+        turtle_data = graph.serialize(format="turtle")
+        return str(turtle_data)
+    else:
+        return str(new_meta)

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -71,8 +71,9 @@ def generate_mapping(
     new_meta["uri"] = uri
     new_meta["type"] = "MachineLearningModel"
 
-    # FIXME(aloga): we replace this here, manually, but ai4os metadata should be
-    # fixed to use the correct format, and not use strings but objects.
+    # NOTE(aloga): we replace this here, manually, but ai4os metadata should be
+    # fixed to use the correct format, and not use strings but objects. However, we
+    # can leave as it is for now, in order not to break things.
     new_meta["categories"] = [
         cat.replace(" ", "_") for cat in new_meta.get("categories", [])
     ]

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -76,9 +76,7 @@ def generate_mapping(
     new_meta["categories"] = [
         cat.replace(" ", "_") for cat in new_meta.get("categories", [])
     ]
-    new_meta["tasks"] = [
-        task.replace(" ", "_") for task in new_meta.get("tasks", [])
-    ]
+    new_meta["tasks"] = [task.replace(" ", "_") for task in new_meta.get("tasks", [])]
     new_meta["libraries"] = [
         lib.replace(" ", "_") for lib in new_meta.get("libraries", [])
     ]

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -89,4 +89,4 @@ def generate_mapping(
         turtle_data = graph.serialize(format="turtle")
         return str(turtle_data)
     else:
-        return str(new_meta)
+        return json.dumps(new_meta)

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -133,7 +133,6 @@ def _map(
     except exceptions.InvalidJSONError:
         from_metadata = utils.load_yaml(from_file)
 
-    # aux = mapping(meta, from_profile, to_format, to_profile, metadata_version)
     try:
         mapping = generate_mapping(
             from_profile=from_profile,

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -6,7 +6,7 @@ import json
 
 import rdflib
 
-import ai4_metadata
+from ai4_metadata import metadata
 from ai4_metadata import exceptions
 
 
@@ -16,7 +16,7 @@ _url_prefix = (
     "https://github.com/ai4os/ai4-metadata/raw/refs/heads/mldcat-ap/src/"
     "ai4_metadata/mapping/json-ld/"
 )
-MetadataVersions = ai4_metadata.MetadataVersions
+MetadataVersions = metadata.MetadataVersions
 
 _JSON_LD_CONTEXT = {
     MetadataVersions.V2: f"{_url_prefix}/mldcat-ap-context-2.0.0.jsonld",

--- a/src/ai4_metadata/mapping/profiles/mldcat.py
+++ b/src/ai4_metadata/mapping/profiles/mldcat.py
@@ -16,10 +16,8 @@ from ai4_metadata import utils
 from ai4_metadata import validate
 
 
-# FIXME(aloga): this is a placeholder for now, change to final value when we merge
-# the code in the main branch
 _url_prefix = (
-    "https://github.com/ai4os/ai4-metadata/raw/refs/heads/mldcat-ap/src/"
+    "https://github.com/ai4os/ai4-metadata/raw/refs/heads/master/src/"
     "ai4_metadata/mapping/json-ld/"
 )
 MetadataVersions = metadata.MetadataVersions

--- a/src/ai4_metadata/metadata.py
+++ b/src/ai4_metadata/metadata.py
@@ -8,6 +8,7 @@ class MetadataVersions(str, enum.Enum):
     """Available versions of the AI4 metadata schema."""
 
     V2 = "2.2.0"
+    V2_3_0 = "2.3.0"
     V2_2_0 = "2.2.0"
     V2_1_0 = "2.1.0"
     V2_0_0 = "2.0.0"

--- a/src/ai4_metadata/metadata.py
+++ b/src/ai4_metadata/metadata.py
@@ -1,0 +1,35 @@
+"""Metadata schema for AI4 applications and its versions."""
+
+import enum
+import pathlib
+
+
+class MetadataVersions(str, enum.Enum):
+    """Available versions of the AI4 metadata schema."""
+
+    V2 = "2.2.0"
+    V2_2_0 = "2.2.0"
+    V2_1_0 = "2.1.0"
+    V2_0_0 = "2.0.0"
+
+    V1 = "1.0.0"
+
+
+LATEST_METADATA_VERSION = MetadataVersions.V2
+
+_metadata_version_files = {}
+for version in MetadataVersions:
+    _metadata_version_files[version] = pathlib.Path(
+        pathlib.Path(__file__).parent
+        / f"schemata/ai4-apps-v{version._value_}.json"  # noqa(W503)
+    )
+
+
+def get_latest_version() -> MetadataVersions:
+    """Get the latest version of the AI4 metadata schema."""
+    return LATEST_METADATA_VERSION
+
+
+def get_schema(version: MetadataVersions) -> pathlib.Path:
+    """Get the schema file path for a given version."""
+    return _metadata_version_files[version]

--- a/src/ai4_metadata/migrate.py
+++ b/src/ai4_metadata/migrate.py
@@ -9,7 +9,7 @@ import warnings
 
 import typer
 
-import ai4_metadata
+from ai4_metadata import metadata
 from ai4_metadata import validate
 from ai4_metadata import utils
 
@@ -22,7 +22,7 @@ def migrate(instance_file: pathlib.Path) -> collections.OrderedDict:
 
     v2: collections.OrderedDict[str, Any] = collections.OrderedDict()
 
-    v2["metadata_version"] = ai4_metadata.get_latest_version().value
+    v2["metadata_version"] = metadata.get_latest_version().value
     v2["title"] = v1_metadata.get("title")
     v2["summary"] = v1_metadata.get("summary")
     v2["description"] = " ".join(v1_metadata.get("description", []))
@@ -79,7 +79,7 @@ def migrate(instance_file: pathlib.Path) -> collections.OrderedDict:
 
 
 @app.command(name="migrate")
-def main(
+def _main(
     v1_metadata: Annotated[
         pathlib.Path, typer.Argument(help="AI4 application metadata file to migrate.")
     ],
@@ -89,13 +89,13 @@ def main(
     ] = None,
 ):
     """Migrate an AI4 metadata file from V1 to the latest V2 version."""
-    v1_schema = ai4_metadata.get_schema(ai4_metadata.MetadataVersions.V1)
+    v1_schema = metadata.get_schema(metadata.MetadataVersions.V1)
     validate.validate(v1_metadata, v1_schema)
 
     # Migrate metadata
     v2_metadata = migrate(v1_metadata)
-    v2_version = ai4_metadata.get_latest_version()
-    v2_schema = ai4_metadata.get_schema(v2_version)
+    v2_version = metadata.get_latest_version()
+    v2_schema = metadata.get_schema(v2_version)
     validate.validate(v2_metadata, v2_schema)
 
     # Write out the migrated metadata
@@ -107,7 +107,7 @@ def main(
         )
 
 
-def migrate_main():
+def _migrate_main():
     """Run the migration command as an independent script."""
     # NOTE(aloga): This is a workaround to be able to provide the command as a separate
     # script, in order to be compatible with previous versions of the package. However,
@@ -120,4 +120,4 @@ def migrate_main():
     )
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
     utils.format_rich_warning(DeprecationWarning(msg))
-    typer.run(main)
+    typer.run(_main)

--- a/src/ai4_metadata/schemata/ai4-apps-v2.1.0.json
+++ b/src/ai4_metadata/schemata/ai4-apps-v2.1.0.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/ai4os/ai4-metadata/blob/master/src/ai4_metadata/schemata/ai4-apps-v2.0.0.json",
+    "$id": "https://github.com/ai4os/ai4-metadata/blob/master/src/ai4_metadata/schemata/ai4-apps-v2.1.0.json",
     "type": "object",
     "properties": {
         "metadata_version": {

--- a/src/ai4_metadata/schemata/ai4-apps-v2.2.0.json
+++ b/src/ai4_metadata/schemata/ai4-apps-v2.2.0.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/ai4os/ai4-metadata/blob/master/src/ai4_metadata/schemata/ai4-apps-v2.0.0.json",
+    "$id": "https://github.com/ai4os/ai4-metadata/blob/master/src/ai4_metadata/schemata/ai4-apps-v2.2.0.json",
     "type": "object",
     "properties": {
         "metadata_version": {

--- a/src/ai4_metadata/schemata/ai4-apps-v2.3.0.json
+++ b/src/ai4_metadata/schemata/ai4-apps-v2.3.0.json
@@ -1,0 +1,307 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/ai4os/ai4-metadata/blob/master/src/ai4_metadata/schemata/ai4-apps-v2.3.0.json",
+    "type": "object",
+    "properties": {
+        "metadata_version": {
+            "description": "Version of the metadata schema.",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "2.1.0",
+            "type": "string"
+        },
+        "title": {
+            "description": "Name of the Data Science application.",
+            "type": "string",
+            "user_friendly": "Title",
+            "example": "Deep Learning Model for Metadata Classification"
+        },
+        "summary": {
+            "description": "Short text describing the value of the Data Science application.",
+            "type": "string",
+            "user_friendly": "Summary",
+            "example": "This model classifies metadata using deep learning techniques."
+        },
+        "description": {
+            "description": "Elaborated description of the Data Science application.",
+            "type": "string",
+            "user_friendly": "Description",
+            "example": "This model uses a deep learning architecture to classify metadata into different categories. The model is trained on a dataset of 10,000 metadata entries and achieves an accuracy of 90%."
+        },
+        "doi" : {
+            "description": "DOI of the Data Science application.",
+            "type": "string",
+            "format": "doi",
+            "user_friendly": "Digital Object Identifier",
+            "example": "10.5281/zenodo.1234567"
+        },
+        "links": {
+            "title": "links",
+            "type": "object",
+            "properties": {
+                "self": {
+                    "description": "URL pointing to the metadata of the Data Science application.",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Metadata URL",
+                    "example": "https://example.org/metadata"
+                },
+                "documentation": {
+                    "description": "URL pointing to the relevant documentation.",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Documentation URL",
+                    "example": "https://example.org/docs"
+                },
+                "source_code": {
+                    "description": "URL pointing to the relevant source code.",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Source Code URL",
+                    "example": "https://example.org/code"
+                },
+                "docker_image": {
+                    "description": "URL pointing to the relevant Docker image.",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Docker Image URL",
+                    "example": "https://example.org/docker"
+                },
+                "zenodo_doi": {
+                    "description": "DOI of the Zenodo record.",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Link to Zenodo DOI",
+                    "example": "https://doi.org/10.5281/zenodo.1234567"
+                },
+                "dataset": {
+                    "description": "URL pointing to the relevant training dataset.",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Traning Dataset URL",
+                    "example": "https://example.org/dataset"
+                },
+                "weights": {
+                    "description": "URL of file containing weights from training",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Weights URL",
+                    "example": "https://example.org/weights"
+                },
+                "citation": {
+                    "description": "URL pointing to the relevant citation. Please use a Citation File Format (CFF) if possible.",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Citation URL",
+                    "example": "https://example.org/citation.cff"
+                },
+                "base_model": {
+                    "description": "URL pointing to a base model if this model is a fine-tune, adaptation, etc. of another one.",
+                    "type": "string",
+                    "format": "uri",
+                    "user_friendly": "Base Model URL",
+                    "example": "https://example.org/base_model"
+                }
+            },
+            "required": [
+                "source_code"
+            ]
+        },
+        "dates": {
+            "title": "dates",
+            "type": "object",
+            "properties": {
+                "created": {
+                    "description": "Creation date of the Data Science application.",
+                    "type": "string",
+                    "format": "date",
+                    "user_friendly": "Creation Date",
+                    "example": "2022-01-01"
+                },
+                "updated": {
+                    "description": "Last update date of the Data Science application.",
+                    "type": "string",
+                    "format": "date",
+                    "user_friendly": "Last Update Date",
+                    "example": "2024-12-31"
+                }
+            },
+            "required": [
+                "created",
+                "updated"
+            ]
+        },
+        "libraries": {
+            "description": "Libraries used in the Data Science application.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "enum": [
+                    "TensorFlow",
+                    "PyTorch",
+                    "Keras",
+                    "Scikit-learn",
+                    "XGBoost",
+                    "LightGBM",
+                    "CatBoost",
+                    "Other"
+                ]
+            },
+            "user_friendly": "Libraries used",
+            "example": ["TensorFlow", "PyTorch"]
+        },
+        "tasks": {
+            "description": "Topic/s for the tasks that categorize the Data Science application.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "enum": [
+                    "Computer Vision",
+                    "Natural Language Processing",
+                    "Time Series",
+                    "Recommender Systems",
+                    "Anomaly Detection",
+                    "Regression",
+                    "Classification",
+                    "Clustering",
+                    "Dimensionality Reduction",
+                    "Generative Models",
+                    "Graph Neural Networks",
+                    "Optimization",
+                    "Reinforcement Learning",
+                    "Transfer Learning",
+                    "Uncertainty Estimation",
+                    "Other"
+                ]
+            },
+            "user_friendly": "Model Tasks",
+            "example": ["Computer Vision", "Natural Language Processing"]
+        },
+        "categories": {
+            "description": "Platform categories for the tasks that categorize the Data Science application.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "enum": [
+                    "AI4 pre trained",
+                    "AI4 trainable",
+                    "AI4 inference",
+                    "AI4 tools"
+                ]
+            },
+            "user_friendly": "AI4 Platform Categories",
+            "example": ["AI4 pre trained", "AI4 trainable"]
+        },
+        "tags": {
+            "description": "User provided tags to best describe the Data Science application.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            },
+            "user_friendly": "Tags",
+            "example": ["Deep Learning", "Metadata Classification"]
+        },
+        "data-type": {
+            "description": "Data type used in the Data Science application.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "enum": [
+                    "Image",
+                    "Text",
+                    "Time Series",
+                    "Tabular",
+                    "Graph",
+                    "Audio",
+                    "Video",
+                    "Other"
+                ]
+            },
+            "user_friendly": "Data Type",
+            "example": ["Text"]
+        },
+        "resources": {
+            "description": "Resources (CPU, GPU, storage) needed for the application.",
+            "type": "object",
+            "properties": {
+                "inference": {
+                    "description": "Minimum / recommended resources needed for inference.",
+                    "$ref": "#/definitions/resource-configuration"
+                },
+                "training": {
+                    "description": "Minimum / recommended resources needed for training.",
+                    "$ref": "#/definitions/resource-configuration"
+                }
+            }
+        }
+    },
+    "required": [
+        "metadata_version",
+        "title",
+        "summary",
+        "description",
+        "links",
+        "libraries",
+        "tasks",
+        "categories",
+        "tags"
+    ],
+    "not": {
+        "anyOf": [
+            { "required": ["tosca"] },
+            { "required": ["sources"] },
+            { "required": ["dataset_url"] },
+            { "required": ["cite_url"] },
+            { "required": ["date_creation"] },
+            { "required": ["keywords"] }
+        ]
+    },
+    "definitions": {
+        "resource-configuration": {
+            "description": "Computational resources needed for the tasks",
+            "type": "object",
+            "properties": {
+                "cpu": {
+                    "description": "Number of CPUs needed for the task",
+                    "type": "integer",
+                    "minimum": 0,
+                    "example": 1
+                },
+                "gpu": {
+                    "description": "Number of GPUs needed for the task",
+                    "type": "integer",
+                    "minimum": 0,
+                    "example": 1
+                },
+                "memory_MB": {
+                    "description": "Memory needed for the task (in MB)",
+                    "type": "integer",
+                    "minimum": 0,
+                    "example": 8000
+                },
+                "gpu_memory_MB": {
+                    "description": "GPU memory needed for the task (in MB)",
+                    "type": "integer",
+                    "minimum": 0,
+                    "example": 8000
+                },
+                "gpu_compute_capability": {
+                    "description": "GPU compute capability needed for the task. Check https://developer.nvidia.com/cuda-gpus",
+                    "type": "number",
+                    "minimum": 0,
+                    "example": 6.1
+                },
+                "storage_MB": {
+                    "description": "Storage needed for the task (in MB)",
+                    "type": "integer",
+                    "minimum": 0,
+                    "example": 10000
+                }
+            }
+        }
+    }
+}

--- a/src/ai4_metadata/validate.py
+++ b/src/ai4_metadata/validate.py
@@ -9,7 +9,7 @@ import warnings
 
 import typer
 
-import ai4_metadata
+from ai4_metadata import metadata
 from ai4_metadata import exceptions
 from ai4_metadata import utils
 
@@ -48,7 +48,7 @@ def validate(
 
 
 @app.command(name="validate")
-def main(
+def _main(
     instances: Annotated[
         List[pathlib.Path],
         typer.Argument(
@@ -62,9 +62,9 @@ def main(
         typer.Option(help="AI4 application metadata schema file to use."),
     ] = None,
     metadata_version: Annotated[
-        ai4_metadata.MetadataVersions,
+        metadata.MetadataVersions,
         typer.Option(help="AI4 application metadata version."),
-    ] = ai4_metadata.get_latest_version(),
+    ] = metadata.get_latest_version(),
     quiet: Annotated[
         bool, typer.Option("--quiet", "-q", help="Suppress output for valid instances.")
     ] = False,
@@ -79,7 +79,7 @@ def main(
 
     If you provide the --shema option, it will override the --metadata-version option.
     """
-    schema_file = schema or ai4_metadata.get_schema(metadata_version)
+    schema_file = schema or metadata.get_schema(metadata_version)
 
     exit_code = 0
     for instance_file in instances:
@@ -113,7 +113,7 @@ def main(
     raise typer.Exit(code=exit_code)
 
 
-def validate_main():
+def _validate_main():
     """Run the validation command as an independent script."""
     # NOTE(aloga): This is a workaround to be able to provide the command as a separate
     # script, in order to be compatible with previous versions of the package. However,
@@ -126,4 +126,4 @@ def validate_main():
     )
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
     utils.format_rich_warning(DeprecationWarning(msg))
-    typer.run(main)
+    typer.run(_main)


### PR DESCRIPTION
This is part of the collaboration with SEMIC support center (https://interoperable-europe.ec.europa.eu/collection/semic-support-centre) to provide a mapping mechanism between the AI4 metadata format and the MLDCAT-AP profile (https://semiceu.github.io/MLDCAT-AP/)

We implement the mapping of AI4 metadata to MLDCAT-AP via JSON-LD context file that allows us to serialize to RDF or JSON-LD.